### PR TITLE
Remove HTTP inserts from integration tests

### DIFF
--- a/mariadb/mariadb.go
+++ b/mariadb/mariadb.go
@@ -31,8 +31,10 @@ type sqlColumn struct {
 }
 
 // GetColumns invokes `SHOW COLUMNS` and uses the output to determine valid columns for each table.
-func (MariaDB) GetColumns(db *sql.DB, t bartlett.Table) ([]string, error) {
-	// TODO store columns the way sqlite3 does
+func (driver *MariaDB) GetColumns(db *sql.DB, t bartlett.Table) ([]string, error) {
+	if driver.tables == nil {
+		driver.tables = make(map[string][]column)
+	}
 	rows, err := db.Query(fmt.Sprintf(`SHOW COLUMNS FROM %s`, t.Name))
 	if err != nil {
 		return []string{}, err
@@ -47,6 +49,7 @@ func (MariaDB) GetColumns(db *sql.DB, t bartlett.Table) ([]string, error) {
 			return columns, err
 		}
 		columns = append(columns, c.Field)
+		driver.tables[t.Name] = append(driver.tables[t.Name], column{name: c.Field, dataType:mysqlTypeToGo(c.Type)})
 	}
 
 	return []string{}, err

--- a/mariadb/mariadb_test.go
+++ b/mariadb/mariadb_test.go
@@ -55,7 +55,7 @@ func TestMariaDB(t *testing.T) {
 		},
 	}
 
-	b := bartlett.Bartlett{db, MariaDB{}, tables, dummyUserProvider}
+	b := bartlett.Bartlett{db, &MariaDB{}, tables, dummyUserProvider}
 
 	testSimpleGetAll(t, b)
 	db.Exec(`DROP TABLE students;`)

--- a/select_test.go
+++ b/select_test.go
@@ -41,10 +41,10 @@ func TestSelect(t *testing.T) {
 
 	rawSQL, args, _ := builder.ToSql()
 	if args[0] != 1 {
-		t.Fatalf(`Expected userID arg to be 1 but got %v instead`, args[0])
+		t.Errorf(`Expected userID arg to be 1 but got %v instead`, args[0])
 	}
 	if !strings.Contains(rawSQL, `student_id =`) {
-		t.Fatalf(`Expected query to require student_id but criterion not found in %s`, rawSQL)
+		t.Errorf(`Expected query to require student_id but criterion not found in %s`, rawSQL)
 	}
 }
 

--- a/sqlite3/sqlite3_test.go
+++ b/sqlite3/sqlite3_test.go
@@ -22,7 +22,17 @@ func TestSQLite3(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	_, err = db.Exec(`INSERT INTO students(age, grade) VALUES(18, 85),(20,91);`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	_, err = db.Exec(`CREATE TABLE teachers(teacher_id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR);`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.Exec(`INSERT INTO teachers(name) VALUES('Mr. Smith'),('Ms. Key');`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,28 +50,6 @@ func TestSQLite3(t *testing.T) {
 	}
 
 	b := bartlett.Bartlett{db, &SQLite3{}, tables, dummyUserProvider}
-
-	studentPost, err := http.NewRequest(`POST`, `https://example.com/students`, strings.NewReader(`[{"age":18,"grade":85},{"age":20,"grade":91}]`))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	teacherPost, err := http.NewRequest(`POST`, `https://example.com/teachers`, strings.NewReader(`[{"name":"Mr. Smith"},{"name":"Ms. Key"}]`))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	routes, handlers := b.Routes()
-
-	for i, route := range routes {
-		if route == `/students` {
-			resp := httptest.NewRecorder()
-			handlers[i](resp, studentPost)
-		} else if route == `/teachers` {
-			resp := httptest.NewRecorder()
-			handlers[i](resp, teacherPost)
-		}
-	}
 
 	testSimpleGetAll(t, b)
 	testUserGetAll(t, b)


### PR DESCRIPTION
It makes testing user queries nearly impossible in its current form.